### PR TITLE
アカウント作成後にダイアログ表示とコンポーネント化

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,31 +17,10 @@
     │   │   │   ├── input.tsx
     │   │   │   └── ...
     │   │   └── index.ts   # コンポーネントのエクスポート
-    │   ├── presentational/  # プレゼンテーショナルコンポーネント
-    │   │   ├── ComponentName/ # 例: Button, Input, Header など
-    │   │   │   ├── index.tsx
-    │   │   │   └── ComponentName.stories.tsx
-    │   │   └── ...
-    │   ├── containers/     # コンテナコンポーネント
-    │   │   ├── ContainerName/
-    │   │   │   ├── index.tsx
-    │   │   │   ├── useContainerHook.ts
-    │   │   │   └── useContainerHook.test.ts
-    │   │   └── ...
     │   └── ...
     ├── features/          # 特定の機能に関するコンポーネント、ロジック、ページ
     │   ├── featureName/   # 例: auth, productList, checkout など
-    │   │   ├── presentational/  # 機能固有の Presentational Components
-    │   │   │   ├── ComponentName/
-    │   │   │   │   ├── index.tsx
-    │   │   │   │   └── ComponentName.stories.tsx
-    │   │   │   └── ...
-    │   │   ├── containers/     # 機能固有の Container Components (ロジックと状態管理)
-    │   │   │   ├── ContainerName/
-    │   │   │   │   ├── index.tsx
-    │   │   │   │   ├── useContainerHook.ts  # コンテナ用のカスタムフック
-    │   │   │   │   └── useContainerHook.test.ts # カスタムフックのテストコード
-    │   │   │   └── ...
+    │   │   ├── components/     # 機能固有のコンポーネント
     │   │   ├── hooks/          # 機能固有のカスタムフック
     │   │   ├── types/          # 機能固有の型定義
     │   │   ├── lib/            # 機能固有の外部ライブラリの設定やラッパー

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,9 +1,7 @@
-import { SignupForm } from "@/features/auth/components/SignupForm";
+import { SignupForm } from '@/features/auth/components/SignupForm';
 
 const Page = () => {
-  return (
-    <SignupForm />
-  );
+  return <SignupForm />;
 };
 
 export default Page;

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,47 +1,8 @@
-import { Button } from '@/components/ui/shadcn/button';
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/shadcn/card';
-import { Input } from '@/components/ui/shadcn/input';
-import { Label } from '@/components/ui/shadcn/label';
-import { signupAction } from '@/features/auth/actions/signupAction';
+import { SignupForm } from "@/features/auth/components/SignupForm";
 
 const Page = () => {
   return (
-    <div className="flex justify-center items-center w-full h-dvh">
-      <Card className="w-full max-w-sm h-fit">
-        <CardHeader>
-          <CardTitle>Create to your account</CardTitle>
-          <CardDescription>SNSで使う名前を入力してください</CardDescription>
-          <CardAction>
-            <Button variant="link">Sign Up</Button>
-          </CardAction>
-        </CardHeader>
-        <CardContent>
-          <form action={signupAction}>
-            <div className="flex flex-col gap-6">
-              <div className="grid gap-2">
-                <Label htmlFor="name">名前</Label>
-                <Input id="name" name="name" required />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="id">プロフィールID</Label>
-                <Input id="id" name="profileId" required />
-              </div>
-              <Button type="submit" className="w-full">
-                アカウント作成
-              </Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
-    </div>
+    <SignupForm />
   );
 };
 

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -1,5 +1,6 @@
-'use client'
+'use client';
 
+import { Button } from '@/components/ui/shadcn/button';
 import {
   Card,
   CardContent,
@@ -14,7 +15,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/shadcn/dialog';
-import { Button } from '@/components/ui/shadcn/button';
 import { useEffect, useState } from 'react';
 
 type PostsType = {
@@ -82,9 +82,7 @@ const Page = () => {
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button onClick={() => setShowDialog(false)}>
-              OK
-            </Button>
+            <Button onClick={() => setShowDialog(false)}>OK</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/components/ui/shadcn/dialog.tsx
+++ b/src/components/ui/shadcn/dialog.tsx
@@ -1,34 +1,34 @@
-'use client'
+'use client';
 
-import * as React from 'react'
-import { cn } from '@/lib/utils'
+import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const Dialog = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & {
-    open?: boolean
-    onOpenChange?: (open: boolean) => void
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
   }
 >(({ className, open, onOpenChange, children, ...props }, ref) => {
   React.useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && open) {
-        onOpenChange?.(false)
+        onOpenChange?.(false);
       }
-    }
+    };
 
     if (open) {
-      document.addEventListener('keydown', handleEscape)
-      document.body.style.overflow = 'hidden'
+      document.addEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'hidden';
     }
 
     return () => {
-      document.removeEventListener('keydown', handleEscape)
-      document.body.style.overflow = 'unset'
-    }
-  }, [open, onOpenChange])
+      document.removeEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'unset';
+    };
+  }, [open, onOpenChange]);
 
-  if (!open) return null
+  if (!open) return null;
 
   return (
     <div
@@ -40,7 +40,7 @@ const Dialog = React.forwardRef<
         className={cn(
           'relative bg-white rounded-lg shadow-lg p-6 w-full max-w-md mx-4',
           'animate-in fade-in-0 zoom-in-95 duration-200',
-          className
+          className,
         )}
         onClick={(e) => e.stopPropagation()}
         {...props}
@@ -48,9 +48,9 @@ const Dialog = React.forwardRef<
         {children}
       </div>
     </div>
-  )
-})
-Dialog.displayName = 'Dialog'
+  );
+});
+Dialog.displayName = 'Dialog';
 
 const DialogHeader = React.forwardRef<
   HTMLDivElement,
@@ -58,11 +58,14 @@ const DialogHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)}
+    className={cn(
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className,
+    )}
     {...props}
   />
-))
-DialogHeader.displayName = 'DialogHeader'
+));
+DialogHeader.displayName = 'DialogHeader';
 
 const DialogTitle = React.forwardRef<
   HTMLParagraphElement,
@@ -70,11 +73,14 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h3
     ref={ref}
-    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className,
+    )}
     {...props}
   />
-))
-DialogTitle.displayName = 'DialogTitle'
+));
+DialogTitle.displayName = 'DialogTitle';
 
 const DialogDescription = React.forwardRef<
   HTMLParagraphElement,
@@ -85,16 +91,16 @@ const DialogDescription = React.forwardRef<
     className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
-))
-DialogDescription.displayName = 'DialogDescription'
+));
+DialogDescription.displayName = 'DialogDescription';
 
 const DialogContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div ref={ref} className={cn('pt-0', className)} {...props} />
-))
-DialogContent.displayName = 'DialogContent'
+));
+DialogContent.displayName = 'DialogContent';
 
 const DialogFooter = React.forwardRef<
   HTMLDivElement,
@@ -102,11 +108,14 @@ const DialogFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
+    )}
     {...props}
   />
-))
-DialogFooter.displayName = 'DialogFooter'
+));
+DialogFooter.displayName = 'DialogFooter';
 
 export {
   Dialog,
@@ -115,4 +124,4 @@ export {
   DialogDescription,
   DialogContent,
   DialogFooter,
-}
+};

--- a/src/components/ui/shadcn/dialog.tsx
+++ b/src/components/ui/shadcn/dialog.tsx
@@ -34,6 +34,11 @@ const Dialog = React.forwardRef<
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={() => onOpenChange?.(false)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          onOpenChange?.(false);
+        }
+      }}
     >
       <div
         ref={ref}

--- a/src/components/ui/shadcn/dialog.tsx
+++ b/src/components/ui/shadcn/dialog.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const Dialog = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & {
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+  }
+>(({ className, open, onOpenChange, children, ...props }, ref) => {
+  React.useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && open) {
+        onOpenChange?.(false)
+      }
+    }
+
+    if (open) {
+      document.addEventListener('keydown', handleEscape)
+      document.body.style.overflow = 'hidden'
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape)
+      document.body.style.overflow = 'unset'
+    }
+  }, [open, onOpenChange])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={() => onOpenChange?.(false)}
+    >
+      <div
+        ref={ref}
+        className={cn(
+          'relative bg-white rounded-lg shadow-lg p-6 w-full max-w-md mx-4',
+          'animate-in fade-in-0 zoom-in-95 duration-200',
+          className
+        )}
+        onClick={(e) => e.stopPropagation()}
+        {...props}
+      >
+        {children}
+      </div>
+    </div>
+  )
+})
+Dialog.displayName = 'Dialog'
+
+const DialogHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)}
+    {...props}
+  />
+))
+DialogHeader.displayName = 'DialogHeader'
+
+const DialogTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = 'DialogTitle'
+
+const DialogDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = 'DialogDescription'
+
+const DialogContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('pt-0', className)} {...props} />
+))
+DialogContent.displayName = 'DialogContent'
+
+const DialogFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    {...props}
+  />
+))
+DialogFooter.displayName = 'DialogFooter'
+
+export {
+  Dialog,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogContent,
+  DialogFooter,
+}

--- a/src/features/auth/actions/signupAction.ts
+++ b/src/features/auth/actions/signupAction.ts
@@ -9,8 +9,8 @@ type Arguments = {
 };
 
 type SignupState = {
-  id?: number
-}
+  id?: number;
+};
 
 const signup = async ({ name, profileId }: Arguments) => {
   const client = getClient();
@@ -36,13 +36,16 @@ const signup = async ({ name, profileId }: Arguments) => {
   }
 };
 
-export const signupAction = async (prevState: SignupState, queryData: FormData): Promise<SignupState> => {
+export const signupAction = async (
+  prevState: SignupState,
+  queryData: FormData,
+): Promise<SignupState> => {
   const name = queryData.get('name') as string;
   const profileId = queryData.get('profileId') as string;
 
   const id = await signup({ name, profileId });
 
   return {
-    id
-  }
+    id,
+  };
 };

--- a/src/features/auth/actions/signupAction.ts
+++ b/src/features/auth/actions/signupAction.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import { getClient } from '@/db/client';
 import { users } from '@/db/schema/users';
 
@@ -5,6 +7,10 @@ type Arguments = {
   name: string;
   profileId: string;
 };
+
+type SignupState = {
+  id?: number
+}
 
 const signup = async ({ name, profileId }: Arguments) => {
   const client = getClient();
@@ -30,10 +36,13 @@ const signup = async ({ name, profileId }: Arguments) => {
   }
 };
 
-export const signupAction = async (formData: FormData) => {
-  'use server';
-  const name = formData.get('name') as string;
-  const profileId = formData.get('profileId') as string;
+export const signupAction = async (prevState: SignupState, queryData: FormData): Promise<SignupState> => {
+  const name = queryData.get('name') as string;
+  const profileId = queryData.get('profileId') as string;
 
   const id = await signup({ name, profileId });
+
+  return {
+    id
+  }
 };

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import { Button } from '@/components/ui/shadcn/button';
 import {
@@ -16,15 +16,15 @@ import { useRouter } from 'next/navigation';
 import { useActionState, useEffect } from 'react';
 
 export const SignupForm = () => {
-  const [formState, formAction, isPending] = useActionState(signupAction, {})
-  const router = useRouter()
+  const [formState, formAction, isPending] = useActionState(signupAction, {});
+  const router = useRouter();
 
   useEffect(() => {
     if (!isPending && formState?.id) {
       sessionStorage.setItem('newUserId', formState.id.toString());
       router.push('/timeline');
     }
-  }, [isPending, formState?.id, router.push])
+  }, [isPending, formState?.id, router.push]);
 
   return (
     <div className="flex justify-center items-center w-full h-dvh">
@@ -55,5 +55,5 @@ export const SignupForm = () => {
         </CardContent>
       </Card>
     </div>
-  )
-}
+  );
+};

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -24,7 +24,7 @@ export const SignupForm = () => {
     if (!isPending && formState?.id) {
       router.push('/timeline');
     }
-  })
+  }, [isPending, formState])
 
   return (
     <div className="flex justify-center items-center w-full h-dvh">

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -6,7 +6,6 @@ import {
   CardAction,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from '@/components/ui/shadcn/card';

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -21,6 +21,7 @@ export const SignupForm = () => {
 
   useEffect(() => {
     if (!isPending && formState?.id) {
+      sessionStorage.setItem('newUserId', formState.id.toString());
       router.push('/timeline');
     }
   }, [isPending, formState?.id, router.push])

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { Button } from '@/components/ui/shadcn/button';
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/shadcn/card';
+import { Input } from '@/components/ui/shadcn/input';
+import { Label } from '@/components/ui/shadcn/label';
+import { signupAction } from '@/features/auth/actions/signupAction';
+import { useRouter } from 'next/navigation';
+import { useActionState, useEffect } from 'react';
+
+export const SignupForm = () => {
+  const [formState, formAction, isPending] = useActionState(signupAction, {})
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!isPending && formState?.id) {
+      router.push('/timeline');
+    }
+  })
+
+  return (
+    <div className="flex justify-center items-center w-full h-dvh">
+      <Card className="w-full max-w-sm h-fit">
+        <CardHeader>
+          <CardTitle>Create to your account</CardTitle>
+          <CardDescription>SNSで使う名前を入力してください</CardDescription>
+          <CardAction>
+            <Button variant="link">Sign Up</Button>
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <form action={formAction}>
+            <div className="flex flex-col gap-6">
+              <div className="grid gap-2">
+                <Label htmlFor="name">名前</Label>
+                <Input id="name" name="name" required />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="id">プロフィールID</Label>
+                <Input id="id" name="profileId" required />
+              </div>
+              <Button type="submit" className="w-full">
+                アカウント作成
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -24,7 +24,7 @@ export const SignupForm = () => {
     if (!isPending && formState?.id) {
       router.push('/timeline');
     }
-  }, [isPending, formState])
+  }, [isPending, formState?.id, router.push])
 
   return (
     <div className="flex justify-center items-center w-full h-dvh">

--- a/src/features/timeline/components/Timeline.tsx
+++ b/src/features/timeline/components/Timeline.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import {
   Card,
@@ -15,7 +15,7 @@ type PostsType = {
 };
 
 const Page = () => {
-  const [showDialog, setShowDialog] = useState()
+  const [showDialog, setShowDialog] = useState();
 
   useEffect(() => {
     const newUserId = sessionStorage.getItem('newUserId');

--- a/src/features/timeline/components/Timeline.tsx
+++ b/src/features/timeline/components/Timeline.tsx
@@ -15,7 +15,7 @@ type PostsType = {
 };
 
 const Page = () => {
-  const [showDialog, setShowDialog] = useState();
+  const [showDialog, setShowDialog] = useState<boolean>(false);
 
   useEffect(() => {
     const newUserId = sessionStorage.getItem('newUserId');

--- a/src/features/timeline/components/Timeline.tsx
+++ b/src/features/timeline/components/Timeline.tsx
@@ -6,15 +6,6 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/shadcn/card';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/shadcn/dialog';
-import { Button } from '@/components/ui/shadcn/button';
 import { useEffect, useState } from 'react';
 
 type PostsType = {
@@ -24,14 +15,13 @@ type PostsType = {
 };
 
 const Page = () => {
-  const [showDialog, setShowDialog] = useState(false);
-  const [newUserId, setNewUserId] = useState<string | null>(null);
+  const [showDialog, setShowDialog] = useState()
 
   useEffect(() => {
-    const userId = sessionStorage.getItem('newUserId');
-    if (userId) {
-      setNewUserId(userId);
+    const newUserId = sessionStorage.getItem('newUserId');
+    if (newUserId) {
       setShowDialog(true);
+      // 表示後すぐに削除（一度だけ表示）
       sessionStorage.removeItem('newUserId');
     }
   }, []);
@@ -72,22 +62,6 @@ const Page = () => {
           <PostCard key={post.id} name={post.name} content={post.content} />
         ))}
       </div>
-
-      <Dialog open={showDialog} onOpenChange={setShowDialog}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>アカウント作成完了</DialogTitle>
-            <DialogDescription>
-              ユーザーID: {newUserId} でアカウントが作成されました！
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button onClick={() => setShowDialog(false)}>
-              OK
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { type ClassValue, clsx } from 'clsx'
-import { twMerge } from 'tailwind-merge'
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
## Summary
- アカウント作成フォームをコンポーネント化
- アカウント作成後にダイアログで成功メッセージを表示
- Dialogコンポーネントの実装
- ディレクトリ構造の見直し

## 変更内容
- `SignupForm`コンポーネントを新規作成してフォームロジックを分離
- `useActionState`を使用してServer Actionsの状態管理を実装
- アカウント作成成功後にタイムラインページへリダイレクト
- セッションストレージを使用してユーザーIDを一時保存
- `Dialog`コンポーネントの実装（shadcn/ui風のスタイル）
- タイムラインページでアカウント作成完了ダイアログを表示

## Test plan
- [x] アカウント作成フォームが正常に動作する
- [x] フォーム送信後にタイムラインページへリダイレクトされる
- [x] アカウント作成完了ダイアログが表示される
- [x] ダイアログのOKボタンで閉じることができる
- [x] 型チェックとlintが通る

🤖 Generated with [Claude Code](https://claude.ai/code)